### PR TITLE
Fix duplicate shortcode when cms.page.init again

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -18,6 +18,8 @@ class Plugin extends PluginBase
 {
 
     protected $shortcodesManager;
+	
+    protected $shortcodeHandlersIsInit;
 
     /**
      * @var array Plugin dependencies
@@ -69,15 +71,18 @@ class Plugin extends PluginBase
             ]
         ];
     }
-
-	public function boot()
+ 
+    public function boot()
     {
         $shortcodesManager = $this->shortcodesManager = new shortcodesManager();
 
         Event::listen('cms.page.init', function ($controller, $page) {
             $this->shortcodesManager->resetObjects();
             $this->shortcodesManager->resetAssets();
-            $onshortcodeHandlers = Event::fire('linkonoid.shortcodesengine.onshortcodeHandlers',[$this->shortcodesManager]);
+            if(!$this->shortcodeHandlersIsInit){
+                Event::fire('linkonoid.shortcodesengine.onshortcodeHandlers',[$this->shortcodesManager]);
+                $this->shortcodeHandlersIsInit = true;
+            }
         });
 
         Event::listen('linkonoid.shortcodesengine.onshortcodeHandlers', function () {


### PR DESCRIPTION
Ситуация: попытка вернуть 404 страницу с другой страницы, если в базе не найдена запись.

Страница 404 возвращается по стандартной схеме:
```php
return $this->controller->run('404');
```
(https://tyapk.ru/blog/post/return-404-from-an-octobercms-component)

Отчего срабатывает 2 раза событие `cms.page.init`, что в свою очередь вызывает повторную регистрацию шорткодов.
Это приводит к выбросу исключения, говорящее о том что шорткод с таким именем уже есть.

![Снимок экрана от 2020-11-13 19-30-44](https://user-images.githubusercontent.com/1047595/99104724-6a42ad00-25f2-11eb-80e8-c746ff5d4b08.png)

Проблема решена "в лоб".